### PR TITLE
Date error

### DIFF
--- a/EntityManager/ThreadManager.php
+++ b/EntityManager/ThreadManager.php
@@ -363,10 +363,11 @@ class ThreadManager extends BaseThreadManager
                     $timestamp = max($timestamp, $message->getTimestamp());
                 }
             }
-
-            $date = new \DateTime();
-            $date->setTimestamp($timestamp);
-            $meta->setLastMessageDate($date);
+            if ($timestamp) {
+                $date = new \DateTime();
+                $date->setTimestamp($timestamp);
+                $meta->setLastMessageDate($date);
+            }
         }
     }
 


### PR DESCRIPTION
Else we have "1970 ..." in lastMessageDate instead of NULL and new topic without response are diplayed in sender's inbox list with wrong sort (because we have "where lastmessage IS NOT NULL" in getParticipantSentThreadsQueryBuilder)

If we want new topic whitout response display in sender's inbox list, just add in more this fix, a constructor in ThreadMetadata with
$this->lastMessageDate = new \DateTime();
