### PR TITLE
Namespace twig comment block

### DIFF
--- a/Resources/views/Message/inbox.html.twig
+++ b/Resources/views/Message/inbox.html.twig
@@ -1,6 +1,6 @@
 {% extends 'OrnicarMessageBundle::layout.html.twig' %}
 
-{% block content %}
+{% block ornicar_message_content %}
 
 <h2>{% trans from 'OrnicarMessageBundle' %}inbox{% endtrans %}</h2>
 

--- a/Resources/views/Message/newThread.html.twig
+++ b/Resources/views/Message/newThread.html.twig
@@ -1,6 +1,6 @@
 {% extends 'OrnicarMessageBundle::layout.html.twig' %}
 
-{% block content %}
+{% block ornicar_message_content %}
 
 <h2>{% trans from 'OrnicarMessageBundle' %}send_new{% endtrans %}</h2>
 

--- a/Resources/views/Message/search.html.twig
+++ b/Resources/views/Message/search.html.twig
@@ -1,6 +1,6 @@
 {% extends 'OrnicarMessageBundle::layout.html.twig' %}
 
-{% block content %}
+{% block ornicar_message_content %}
 
 <h2>{% trans from 'OrnicarMessageBundle' %}search{% endtrans %}</h2>
 

--- a/Resources/views/Message/sent.html.twig
+++ b/Resources/views/Message/sent.html.twig
@@ -1,6 +1,6 @@
 {% extends 'OrnicarMessageBundle::layout.html.twig' %}
 
-{% block content %}
+{% block ornicar_message_content %}
 
 <h2>{% trans from 'OrnicarMessageBundle' %}messenger{% endtrans %}</h2>
 

--- a/Resources/views/Message/thread.html.twig
+++ b/Resources/views/Message/thread.html.twig
@@ -1,6 +1,6 @@
 {% extends 'OrnicarMessageBundle::layout.html.twig' %}
 
-{% block content %}
+{% block ornicar_message_content %}
 
 <h2>{{ thread.subject }}</h2>
 

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -14,7 +14,7 @@
             <li><a href="{{ url('ornicar_message_sent') }}">{% trans from 'OrnicarMessageBundle' %}sent{% endtrans %}</a></li>
         </ul>
 
-        {% block content %}{% endblock %}
+        {% block ornicar_message_content %}{% endblock %}
 
     </body>
 </html>


### PR DESCRIPTION
We use `content` as the name of our main twig block for displaying site content, so when using the MessageBundle, there's no way to add extra data to the block (title, links to inbox/sent, etc) if it needs to inherit from another template (like `base.html.twig`). 

This PR solves that problem in a similar way to the FOSUserBundle by making the block used by the bundle `ornicar_message_content` instead of just `content`.

I realize this is a bit of a BC break, but it can be resolved by overriding the bundle's `layout.html.twig` and wrapping the block like so:

```
{% block content %}
    {% block ornicar_message_content %}{% endblock %}
{% endblock %}
```
