### PR TITLE
proper dir paths in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "doctrine/mongodb-odm-bundle": "dev-master"
     },
     "autoload": {
-        "psr-0": { "Ornicar\\OrnicarMessageBundle": "" }
+        "psr-0": { "Ornicar\\MessageBundle": "" }
     },
-    "target-dir": "Ornicar/OrnicarMessageBundle"
+    "target-dir": "Ornicar/MessageBundle"
 }


### PR DESCRIPTION
when installing from composer and generating autoload automatically, the path is wrong and show error "Class 'Ornicar\MessageBundle\OrnicarMessageBundle' not found". I think the proper dir path must be set in composer.json - Ornicar/MessageBundle instead of Ornicar/OrnicarMessageBundle.
