### PR TITLE
[sf 2.1 compatibility]

### DIFF
--- a/FormType/NewThreadMessageFormType.php
+++ b/FormType/NewThreadMessageFormType.php
@@ -2,7 +2,7 @@
 
 namespace Ornicar\MessageBundle\FormType;
 
-use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractType;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\Form\AbstractType;
  */
 class NewThreadMessageFormType extends AbstractType
 {
-    public function buildForm(FormBuilder $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add('recipient', 'fos_user_username')

--- a/FormType/ReplyMessageFormType.php
+++ b/FormType/ReplyMessageFormType.php
@@ -2,7 +2,7 @@
 
 namespace Ornicar\MessageBundle\FormType;
 
-use Symfony\Component\Form\FormBuilder;
+use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Form\AbstractType;
 
 /**
@@ -12,7 +12,7 @@ use Symfony\Component\Form\AbstractType;
  */
 class ReplyMessageFormType extends AbstractType
 {
-    public function buildForm(FormBuilder $builder, array $options)
+    public function buildForm(FormBuilderInterface $builder, array $options)
     {
         $builder
             ->add('body', 'textarea');


### PR DESCRIPTION
Update the form types to be compatible with latest 2.1 branch.

In 2.1 (currently symfony master), the `FormTypeInterface` has been changed so that `FormTypeInterface::build()` now takes a `FormBuilderInterface` as its first argument instead of the previous `FormBuilder`.

`FormBuilderInterface` is not available in symfony 2.0.\* so this change would introduce a compatibility break in this case. I see there is a "legacy" branch, I don't know if it's used for compatibility with 2.0.\* or not...
