### PR TITLE
Order of paths in Resources/config/routing.xml

### DIFF
--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -20,13 +20,13 @@
         <default key="_controller">FOSMessageBundle:Message:newThread</default>
     </route>
 
-    <route id="fos_message_thread_view" pattern="/{threadId}">
-        <default key="_controller">FOSMessageBundle:Message:thread</default>
-    </route>
-
     <route id="fos_message_thread_delete" pattern="/{threadId}/delete">
         <default key="_controller">FOSMessageBundle:Message:delete</default>
         <requirement key="_method">POST|DELETE</requirement>
+    </route>
+
+    <route id="fos_message_thread_view" pattern="/{threadId}">
+        <default key="_controller">FOSMessageBundle:Message:thread</default>
     </route>
 
 </routes>


### PR DESCRIPTION
I did it because Symfony2.1 load fos_message_thread_view in priority of the other path when we try to delete a thread. With this modification, the path fos_message_thread_delete works because the routing service load it before. It was conflictual because these two paths begins with same text.
