### PR TITLE
Replace zero by false in dql queries

### DIFF
--- a/EntityManager/MessageManager.php
+++ b/EntityManager/MessageManager.php
@@ -71,7 +71,8 @@ class MessageManager extends BaseMessageManager
             ->where('p.id = :participant_id')
             ->setParameter('participant_id', $participant->getId())
 
-            ->andWhere('mm.isRead = FALSE')
+            ->andWhere('mm.isRead = :isRead')
+            ->setParameter('isRead', false)
 
             ->getQuery()
             ->getSingleScalarResult();

--- a/EntityManager/ThreadManager.php
+++ b/EntityManager/ThreadManager.php
@@ -95,10 +95,12 @@ class ThreadManager extends BaseThreadManager
             ->setParameter('user_id', $participant->getId())
 
             // the thread does not contain spam or flood
-            ->andWhere('t.isSpam = FALSE')
+            ->andWhere('t.isSpam = :isSpam')
+            ->setParameter('isSpam', false)
 
             // the thread is not deleted by this participant
-            ->andWhere('tm.isDeleted = FALSE')
+            ->andWhere('tm.isDeleted = :isDeleted')
+            ->setParameter('isDeleted', false)
 
             // there is at least one message written by an other participant
             ->andWhere('tm.lastMessageDate IS NOT NULL')
@@ -144,10 +146,12 @@ class ThreadManager extends BaseThreadManager
             ->setParameter('user_id', $participant->getId())
 
             // the thread does not contain spam or flood
-            ->andWhere('t.isSpam = FALSE')
+            ->andWhere('t.isSpam = :isSpam')
+            ->setParameter('isSpam', false)
 
             // the thread is not deleted by this participant
-            ->andWhere('tm.isDeleted = FALSE')
+            ->andWhere('tm.isDeleted = :isDeleted')
+            ->setParameter('isDeleted', false)
 
             // there is at least one message written by this participant
             ->andWhere('tm.lastParticipantMessageDate IS NOT NULL')


### PR DESCRIPTION
Reason:

```
An exception occurred while executing 'SELECT COUNT(m0_.id) AS sclr0 FROM Message m1_ INNER JOIN message_message_metadata m0_ ON m1_.id = m0_.message_id INNER JOIN users u2_ ON m0_.participant_id = u2_.id WHERE u2_.id = ? AND m0_.is_read = 0' with params {"1":2}:

SQLSTATE[42883]: Undefined function: 7 ERROR: operator does not exist: boolean = integer
LINE 1: ...articipant_id = u2_.id WHERE u2_.id = $1 AND m0_.is_read = 0
                                                                      ^
HINT: No operator matches the given name and argument type(s). You might need to add explicit type casts.
```
