### PR TITLE
Fixes interface breaking method signature in MessageManager.

### DIFF
--- a/EntityManager/MessageManager.php
+++ b/EntityManager/MessageManager.php
@@ -88,9 +88,9 @@ class MessageManager extends BaseMessageManager
      * @param ReadableInterface $readable
      * @param ParticipantInterface $participant
      */
-    public function markAsReadByParticipant(ThreadInterface $thread, ParticipantInterface $participant)
+    public function markAsReadByParticipant(ReadableInterface $readable, ParticipantInterface $participant)
     {
-        $this->markIsReadByThreadAndParticipant($thread, $participant, true);
+        $readable->setIsReadByParticipant($participant, true);
     }
 
     /**
@@ -99,9 +99,9 @@ class MessageManager extends BaseMessageManager
      * @param ReadableInterface $readable
      * @param ParticipantInterface $participant
      */
-    public function markAsUnreadByParticipant(ThreadInterface $thread, ParticipantInterface $participant)
+    public function markAsUnreadByParticipant(ReadableInterface $readable, ParticipantInterface $participant)
     {
-        $this->markIsReadByThreadAndParticipant($thread, $participant, false);
+        $readable->setIsReadByParticipant($participant, false);
     }
 
     /**


### PR DESCRIPTION
This will fix the errors introduced in pull request #89. Furthermore it fixes issue #91 opened because of #89.

Originally there was the issue #87 which brought not only an inconsistency but an error to my attention. The methods `markAsReadByParticipant` and `markAsUnreadByParticipant` expected a `ReadableInterface` but forwarded it to a method that expected a `ThreadInterface`. I guess this just didn't explode in the past because it is not used in the provided bundle code yet. Now these two methods forward the calls correctly to the methods in the given readable (like the interface ReadableInterface indicates).

We should set up some basic tests. :wink:
