### PR TITLE
Thread->getMessages() should not be overwritten by doctrine:generate:entities

### DIFF
--- a/Resources/doc/concrete_orm.rst
+++ b/Resources/doc/concrete_orm.rst
@@ -182,6 +182,11 @@ Thread class
     	function addMessage(MessageInterface $message) {
     		$this->messages->add($message);
     	}
+
+        public function getMessages()
+        {
+            return parent::getMessages();
+        }
     
     	public function addMetadata(ModelThreadMetadata $meta) {
     	    $meta->setThread($this);


### PR DESCRIPTION
I'm working on Symfony 2.1.5-DEV and Doctrine as ORM.
I followed the documentation on `Creating concrete model classes` and then I run `app/console doctrine:generate:entities [...]`.

In my `src/Acme/MessageBundle/Entity/Thread.php` the function `getMessages()` was automatically generated:

```
    /**
     * Get messages
     *
     * @return \Doctrine\Common\Collections\Collection 
     */
    public function getMessages()
    {
        return $this->messages;
    }
```

But in this way it is returning a `Doctrine/Common/Collections/ArrayCollection` instead of an simple array, as set in [Thread.php#L164](https://github.com/FriendsOfSymfony/FOSMessageBundle/blob/master/Model/Thread.php#L164):

```
    /**
     * @see FOS\MessageBundle\Model\ThreadInterface::getMessages()
     */
    public function getMessages()
    {
        return $this->messages->toArray();
    }
```

Doing so, [reset($messages) in Thread.php#L178](https://github.com/FriendsOfSymfony/FOSMessageBundle/blob/master/Model/Thread.php#L178) and [end($messages) Thread.php#L188](https://github.com/FriendsOfSymfony/FOSMessageBundle/blob/master/Model/Thread.php#L188) would return a `Doctrine/Common/Collections/ArrayCollection` object instead of a simple object, and [thread.lastMessage.id in threads_list.html.twig#L39](https://github.com/FriendsOfSymfony/FOSMessageBundle/blob/master/Resources/views/Message/threads_list.html.twig#L39) and [$thread->getFirstMessage() in ThreadManager.php#L346](https://github.com/FriendsOfSymfony/FOSMessageBundle/blob/master/EntityManager/ThreadManager.php#L346) would have problems because expecting an object instead of an ArrayCollection.

My solution is to propose that `getMessages()` in `src/Acme/MessageBundle/Entity/Thread.php` should not be overwritten by automatically generated functions when running `app/console doctrine:generate:entities`; and to achieve this by adding

```
public function getMessages()
{
    return parent::getMessages();
}
```

in the documentation.
