### PR TITLE
Update dependecies versions for symfony 2.2.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/framework-bundle": "2.1.*",
-        "symfony/twig-bundle": "2.1.*"
+        "symfony/framework-bundle": ">=2.1,<2.3-dev",
+        "symfony/twig-bundle": ">=2.1,<2.3-dev"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "dev-master",


### PR DESCRIPTION
Right now this bundle can't be installed with dev version of Symfony which is 2.2. So requirements should be updated. I copied ones from FOSCommentBundle.
