### PR TITLE
Set fos_message.search_query_factory.default public

### DIFF
--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -51,7 +51,7 @@
             <argument type="service" id="event_dispatcher" />
         </service>
 
-        <service id="fos_message.twig_extension.default" class="FOS\MessageBundle\Twig\Extension\MessageExtension" public="false">
+        <service id="fos_message.twig_extension.default" class="FOS\MessageBundle\Twig\Extension\MessageExtension" public="true">
             <argument type="service" id="fos_message.participant_provider" />
             <argument type="service" id="fos_message.provider" />
             <tag name="twig.extension" alias="fos_message" />


### PR DESCRIPTION
Fixing error : 
ServiceNotFoundException: The service "twig" has a dependency on a non-existent service "fos_message.twig_extension.default".
