### PR TITLE
Update validation.xml

### DIFF
--- a/Resources/config/validation.xml
+++ b/Resources/config/validation.xml
@@ -13,7 +13,7 @@
                     <option name="message">No recipient specified</option>
                 </constraint>
                 <constraint name="Type">
-                    <option name="value">FOS\MessageBundle\Model\ParticipantInterface</option>
+                    <option name="type">FOS\MessageBundle\Model\ParticipantInterface</option>
                 </constraint>
             </constraint>
         </property>
@@ -51,7 +51,7 @@
                 <option name="message">No user with that username</option>
             </constraint>
             <constraint name="Type">
-                <option name="value">FOS\MessageBundle\Model\ParticipantInterface</option>
+                <option name="type">FOS\MessageBundle\Model\ParticipantInterface</option>
             </constraint>
         </property>
 


### PR DESCRIPTION
Type constraint accepts 'type' option, not 'value'. This is to avoid the following error message "The options "value" do not exist in constraint Symfony\Component\Validator\Constraints\Type". See [here](http://symfony.com/doc/current/reference/constraints/Type.html).
