### PR TITLE
Update Thread.php

### DIFF
--- a/Model/Thread.php
+++ b/Model/Thread.php
@@ -175,7 +175,7 @@ abstract class Thread implements ThreadInterface
     {
         $messages = $this->getMessages();
 
-        return empty($messages) ? null : reset($messages);
+        return empty($messages) ? null : $messages->first();
     }
 
     /**
@@ -185,7 +185,7 @@ abstract class Thread implements ThreadInterface
     {
         $messages = $this->getMessages();
 
-        return empty($messages) ? null : end($messages);
+        return empty($messages) ? null : $messages->last();
     }
 
     /**


### PR DESCRIPTION
Bundle crashes when trying to access the first and last element as objects (because it returns an array with pointers, but you are not able to access the methods of the first and last element of the array). This correction returns the actual object, and not an array with the pointer.