### PR TITLE
Fix getOTherParticipants

### DIFF
--- a/Model/Thread.php
+++ b/Model/Thread.php
@@ -287,7 +287,11 @@ abstract class Thread implements ThreadInterface
     {
         $otherParticipants = $this->getParticipants();
 
-        unset($otherParticipants[array_search($participant, $otherParticipants, true)]);
+        $key = array_search($participant, $otherParticipants, true);
+
+        if (false !== $key) {
+            unset($otherParticipants[$key]);
+        }
 
         // we want to reset the array indexes
         return array_values($otherParticipants);


### PR DESCRIPTION
If the participant is not found, array_search will return false and this will remove the first participant from the array
