### PR TITLE
Add deleted threads list

### DIFF
--- a/Controller/MessageController.php
+++ b/Controller/MessageController.php
@@ -38,6 +38,20 @@ class MessageController extends ContainerAware
     }
 
     /**
+     * Displays the authenticated participant deleted threads
+     *
+     * @return Response
+     */
+    public function deletedAction()
+    {
+        $threads = $this->getProvider()->getDeletedThreads();
+
+        return $this->container->get('templating')->renderResponse('FOSMessageBundle:Message:deleted.html.twig', array(
+            'threads' => $threads
+        ));
+    }
+
+    /**
      * Displays a thread, also allows to reply to it
      *
      * @param string $threadId the thread id

--- a/DocumentManager/ThreadManager.php
+++ b/DocumentManager/ThreadManager.php
@@ -140,6 +140,25 @@ class ThreadManager extends BaseThreadManager
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getParticipantDeletedThreadsQueryBuilder(ParticipantInterface $participant)
+    {
+        return $this->repository->createQueryBuilder()
+            ->field('metadata.isDeleted')->equals(true)
+            ->field('metadata.participantId')->equals($participant->getId())
+            ->sort('lastMessageDate', 'desc');
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findParticipantDeletedThreads(ParticipantInterface $participant)
+    {
+        return $this->getParticipantDeletedThreadsQueryBuilder($participant)->getQuery()->execute();
+    }
+
+    /**
      * Finds not deleted threads for a participant,
      * matching the given search term
      * ordered by last message not written by this participant in reverse order.

--- a/EntityManager/ThreadManager.php
+++ b/EntityManager/ThreadManager.php
@@ -178,6 +178,38 @@ class ThreadManager extends BaseThreadManager
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getParticipantDeletedThreadsQueryBuilder(ParticipantInterface $participant)
+    {
+        return $this->repository->createQueryBuilder('t')
+            ->innerJoin('t.metadata', 'tm')
+            ->innerJoin('tm.participant', 'p')
+
+            // the participant is in the thread participants
+            ->andWhere('p.id = :user_id')
+            ->setParameter('user_id', $participant->getId())
+
+            // the thread is deleted by this participant
+            ->andWhere('tm.isDeleted = :isDeleted')
+            ->setParameter('isDeleted', true, \PDO::PARAM_BOOL)
+
+            // sort by date of last message
+            ->orderBy('tm.lastMessageDate', 'DESC')
+        ;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function findParticipantDeletedThreads(ParticipantInterface $participant)
+    {
+        return $this->getParticipantDeletedThreadsQueryBuilder($participant)
+            ->getQuery()
+            ->execute();
+    }
+
+    /**
      * Finds not deleted threads for a participant,
      * matching the given search term
      * ordered by last message not written by this participant in reverse order.

--- a/ModelManager/ThreadManagerInterface.php
+++ b/ModelManager/ThreadManagerInterface.php
@@ -67,6 +67,24 @@ interface ThreadManagerInterface extends ReadableManagerInterface
     function findParticipantSentThreads(ParticipantInterface $participant);
 
     /**
+     * Finds deleted threads from a participant,
+     * ordered by last message date
+     *
+     * @param ParticipantInterface $participant
+     * @return Builder a query builder suitable for pagination
+     */
+    function getParticipantDeletedThreadsQueryBuilder(ParticipantInterface $participant);
+
+    /**
+     * Finds deleted threads from a participant,
+     * ordered by last message date
+     *
+     * @param ParticipantInterface $participant
+     * @return ThreadInterface[]
+     */
+    function findParticipantDeletedThreads(ParticipantInterface $participant);
+
+    /**
      * Finds not deleted threads for a participant,
      * matching the given search term
      * ordered by last message not written by this participant in reverse order.

--- a/Provider/Provider.php
+++ b/Provider/Provider.php
@@ -86,6 +86,16 @@ class Provider implements ProviderInterface
     }
 
     /**
+     * {@inheritDoc}
+     */
+    public function getDeletedThreads()
+    {
+        $participant = $this->getAuthenticatedParticipant();
+
+        return $this->threadManager->findParticipantDeletedThreads($participant);
+    }
+
+    /**
      * Gets a thread by its ID
      * Performs authorization checks
      * Marks the thread as read

--- a/Provider/ProviderInterface.php
+++ b/Provider/ProviderInterface.php
@@ -24,6 +24,13 @@ interface ProviderInterface
      function getSentThreads();
 
     /**
+     * Gets the deleted threads of the current user
+     *
+     * @return ThreadInterface[]
+     */
+     function getDeletedThreads();
+
+    /**
      * Gets a thread by its ID
      * Performs authorization checks
      * Marks the thread as read

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -12,6 +12,10 @@
         <default key="_controller">FOSMessageBundle:Message:sent</default>
     </route>
 
+    <route id="fos_message_deleted" pattern="/deleted">
+        <default key="_controller">FOSMessageBundle:Message:deleted</default>
+    </route>
+
     <route id="fos_message_search" pattern="/search">
         <default key="_controller">FOSMessageBundle:Message:search</default>
     </route>

--- a/Resources/translations/FOSMessageBundle.en.yml
+++ b/Resources/translations/FOSMessageBundle.en.yml
@@ -1,6 +1,7 @@
 messenger:      Messenger
 inbox:          Inbox
 sent:           Sent
+deleted:        Deleted
 send_new:       Send a new message
 search:         Search
 threads_found:  %num% thread found with | %num% threads found with

--- a/Resources/translations/FOSMessageBundle.fr.yml
+++ b/Resources/translations/FOSMessageBundle.fr.yml
@@ -1,6 +1,7 @@
 messenger:      Messagerie
 inbox:          Boîte de réception
 sent:           Envoyés
+deleted:        Supprimés
 send_new:       Envoyer un nouveau message
 search:         Rechercher
 threads_found:  %num% conversations trouvé avec | %num% conversations trouvés avec

--- a/Resources/views/Message/deleted.html.twig
+++ b/Resources/views/Message/deleted.html.twig
@@ -1,0 +1,9 @@
+{% extends 'FOSMessageBundle::layout.html.twig' %}
+
+{% block fos_message_content %}
+
+<h2>{% trans from 'FOSMessageBundle' %}deleted{% endtrans %}</h2>
+
+{% include 'FOSMessageBundle:Message:threads_list.html.twig' with {'threads': threads} %}
+
+{% endblock %}


### PR DESCRIPTION
This PR adds a /deleted route with all user (soft) deleted threads.

I have tested queries in both ORM and ODM, it seems to be ok.
