### PR TITLE
fixed data transformer for null values

### DIFF
--- a/DataTransformer/RecipientsDataTransformer.php
+++ b/DataTransformer/RecipientsDataTransformer.php
@@ -38,7 +38,7 @@ class RecipientsDataTransformer implements DataTransformerInterface
      */
     public function transform($recipients)
     {
-        if ($recipients->count() == 0) {
+        if ($recipients === null || $recipients->count() == 0) {
             return "";
         }
 


### PR DESCRIPTION
when creating form with form.factory got error

Fatal error: Call to a member function count() on a non-object in vendor/friendsofsymfony/message-bundle/FOS/MessageBundle/DataTransformer/RecipientsDataTransformer.php on line 41
