### PR TITLE
hide delete actions if not authorised, toggle between delete and undelete

### DIFF
--- a/Controller/MessageController.php
+++ b/Controller/MessageController.php
@@ -24,7 +24,7 @@ class MessageController extends ContainerAware
     }
 
     /**
-     * Displays the authenticated participant sent mails
+     * Displays the authenticated participant messages sent
      *
      * @return Response
      */
@@ -55,6 +55,7 @@ class MessageController extends ContainerAware
      * Displays a thread, also allows to reply to it
      *
      * @param string $threadId the thread id
+     * 
      * @return Response
      */
     public function threadAction($threadId)
@@ -101,12 +102,29 @@ class MessageController extends ContainerAware
      * Deletes a thread
      * 
      * @param string $threadId the thread id
+     * 
      * @return RedirectResponse
      */
     public function deleteAction($threadId)
     {
         $thread = $this->getProvider()->getThread($threadId);
         $this->container->get('fos_message.deleter')->markAsDeleted($thread);
+        $this->container->get('fos_message.thread_manager')->saveThread($thread);
+
+        return new RedirectResponse($this->container->get('router')->generate('fos_message_inbox'));
+    }
+    
+    /**
+     * Undeletes a thread
+     * 
+     * @param string $threadId
+     * 
+     * @return RedirectResponse
+     */
+    public function undeleteAction($threadId)
+    {
+        $thread = $this->getProvider()->getThread($threadId);
+        $this->container->get('fos_message.deleter')->markAsUndeleted($thread);
         $this->container->get('fos_message.thread_manager')->saveThread($thread);
 
         return new RedirectResponse($this->container->get('router')->generate('fos_message_inbox'));

--- a/Resources/config/config.xml
+++ b/Resources/config/config.xml
@@ -54,6 +54,7 @@
         <service id="fos_message.twig_extension.default" class="FOS\MessageBundle\Twig\Extension\MessageExtension" public="false">
             <argument type="service" id="fos_message.participant_provider" />
             <argument type="service" id="fos_message.provider" />
+            <argument type="service" id="fos_message.authorizer" />
             <tag name="twig.extension" alias="fos_message" />
         </service>
 

--- a/Resources/config/routing.xml
+++ b/Resources/config/routing.xml
@@ -28,6 +28,11 @@
         <default key="_controller">FOSMessageBundle:Message:delete</default>
         <requirement key="_method">POST|DELETE</requirement>
     </route>
+    
+    <route id="fos_message_thread_undelete" pattern="/{threadId}/undelete">
+        <default key="_controller">FOSMessageBundle:Message:undelete</default>
+        <requirement key="_method">POST</requirement>
+    </route>
 
     <route id="fos_message_thread_view" pattern="/{threadId}">
         <default key="_controller">FOSMessageBundle:Message:thread</default>

--- a/Resources/translations/FOSMessageBundle.en.yml
+++ b/Resources/translations/FOSMessageBundle.en.yml
@@ -21,3 +21,4 @@ on:             On %date%
 by:             By %sender%
 no_thread:      There is no thread to show
 delete:         Delete
+undelete:       Undelete

--- a/Resources/views/Message/threads_list.html.twig
+++ b/Resources/views/Message/threads_list.html.twig
@@ -47,9 +47,18 @@
                     {% endif %}
                 </td>
                 <td>
-                    <form action="{{ url('fos_message_thread_delete', {'threadId': thread.id}) }}" method="post">
-                        <input type="submit" value="{% trans from 'FOSMessageBundle' %}delete{% endtrans %}" />
-                    </form>
+                    {% if fos_message_can_delete_thread(thread) %}
+                        {% if fos_message_deleted_by_participant(thread) %}
+                            {% set formAction %}{{ url('fos_message_thread_undelete', {'threadId': thread.id}) }}{% endset %}
+                            {% set submitValue %}{% trans from 'FOSMessageBundle' %}undelete{% endtrans %}{% endset %}
+                        {% else %}
+                            {% set formAction %}{{ url('fos_message_thread_delete', {'threadId': thread.id}) }}{% endset %}
+                            {% set submitValue %}{% trans from 'FOSMessageBundle' %}delete{% endtrans %}{% endset %}
+                        {% endif %}
+                        <form action="{{ formAction }}" method="post">
+                                <input type="submit" value="{{ submitValue }}" />
+                        </form>
+                    {% endif %}
                 </td>
             </tr>
         {% endfor %}

--- a/Twig/Extension/MessageExtension.php
+++ b/Twig/Extension/MessageExtension.php
@@ -5,18 +5,22 @@ namespace FOS\MessageBundle\Twig\Extension;
 use FOS\MessageBundle\Security\ParticipantProviderInterface;
 use FOS\MessageBundle\Model\ReadableInterface;
 use FOS\MessageBundle\Provider\ProviderInterface;
+use FOS\MessageBundle\Model\ThreadInterface;
+use FOS\MessageBundle\Security\AuthorizerInterface;
 
 class MessageExtension extends \Twig_Extension
 {
     protected $participantProvider;
     protected $provider;
+    protected $authorizer;
 
     protected $nbUnreadMessagesCache;
 
-    public function __construct(ParticipantProviderInterface $participantProvider, ProviderInterface $provider)
+    public function __construct(ParticipantProviderInterface $participantProvider, ProviderInterface $provider, AuthorizerInterface $authorizer)
     {
         $this->participantProvider = $participantProvider;
         $this->provider = $provider;
+        $this->authorizer = $authorizer;
     }
 
     /**
@@ -28,7 +32,9 @@ class MessageExtension extends \Twig_Extension
     {
         return array(
             'fos_message_is_read'  => new \Twig_Function_Method($this, 'isRead'),
-            'fos_message_nb_unread' => new \Twig_Function_Method($this, 'getNbUnread')
+            'fos_message_nb_unread' => new \Twig_Function_Method($this, 'getNbUnread'),
+            'fos_message_can_delete_thread' => new \Twig_Function_Method($this, 'canDeleteThread'),
+            'fos_message_deleted_by_participant' => new \Twig_Function_Method($this, 'isThreadDeletedByParticipant')
         );
     }
 
@@ -40,6 +46,31 @@ class MessageExtension extends \Twig_Extension
     public function isRead(ReadableInterface $readable)
     {
         return $readable->isReadByParticipant($this->getAuthenticatedParticipant());
+    }
+    
+    
+    /**
+     * Checks if the participant can mark a thread as deleted
+     * 
+     * @param ThreadInterface $thread
+     * 
+     * @return boolean true if participant can mark a thread as deleted, false otherwise
+     */
+    public function canDeleteThread(ThreadInterface $thread)
+    {
+        return $this->authorizer->canDeleteThread($thread);
+    }
+    
+    /**
+     * Checks if the participant has marked the thread as deleted
+     * 
+     * @param ThreadInterface $thread
+     * 
+     * @return boolean true if participant has marked the thread as deleted, false otherwise
+     */
+    public function isThreadDeletedByParticipant(ThreadInterface $thread)
+    {
+       return $thread->isDeletedByParticipant($this->getAuthenticatedParticipant());
     }
 
     /**


### PR DESCRIPTION
This pull request
-  Hides the delete and  undelete actions from the inlcuded layout if not authorised to delete a thread by the authoriser
-  Makes it possible to undelete a deleted thread
