### PR TITLE
updated the base layout to use bootstrap3

### DIFF
--- a/Resources/translations/FOSMessageBundle.en.yml
+++ b/Resources/translations/FOSMessageBundle.en.yml
@@ -6,7 +6,6 @@ send_new:       Send a new message
 search:         Search
 threads_found:  %num% thread found with | %num% threads found with
 
-message_info:   By %sender%, on %date%
 reply:          Reply
 
 subject:        Subject

--- a/Resources/translations/FOSMessageBundle.nl.yml
+++ b/Resources/translations/FOSMessageBundle.nl.yml
@@ -6,7 +6,6 @@ send_new:       Verstuur een nieuw bericht
 search:         Zoek
 threads_found:  %num% bericht gevonden met | %num% berichten gevonden met
 
-message_info:   Door %sender%, op %date%
 reply:          Reageer
 
 subject:        Onderwerp
@@ -21,3 +20,4 @@ on:             Op %date%
 by:             Door %sender%
 no_thread:      Geen onderwerpen gevonden
 delete:         Verwijder
+undelete:       Publiceer

--- a/Resources/views/Message/inbox.html.twig
+++ b/Resources/views/Message/inbox.html.twig
@@ -4,8 +4,6 @@
 
 <h2>{% trans from 'FOSMessageBundle' %}inbox{% endtrans %}</h2>
 
-<a href="{{ url('fos_message_thread_new' )}}">{% trans from 'FOSMessageBundle' %}send_new{% endtrans %}</a>
-
 {% include 'FOSMessageBundle:Message:threads_list.html.twig' with {'threads': threads} %}
 
 {% endblock %}

--- a/Resources/views/Message/sent.html.twig
+++ b/Resources/views/Message/sent.html.twig
@@ -2,7 +2,7 @@
 
 {% block fos_message_content %}
 
-<h2>{% trans from 'FOSMessageBundle' %}messenger{% endtrans %}</h2>
+<h2>{% trans from 'FOSMessageBundle' %}sent{% endtrans %}</h2>
 
 {% include 'FOSMessageBundle:Message:threads_list.html.twig' with {'threads': threads} %}
 

--- a/Resources/views/Message/thread.html.twig
+++ b/Resources/views/Message/thread.html.twig
@@ -5,12 +5,12 @@
 <h2>{{ thread.subject }}</h2>
 
 {% for message in thread.messages %}
-    <div class="messenger_thread_message">
-        <div class="messenger_thread_message_info">
-            {% trans with {'%sender%': message.sender|e, '%date%': message.createdAt|date} from 'FOSMessageBundle' %}by{% endtrans %}
+    <div class="panel panel-default" id="message_{{ message.id }}">
+        <div class="panel-heading">
+            {% trans with {'%sender%': message.sender|e} from 'FOSMessageBundle' %}by{% endtrans %} {% trans with {'%date%': message.createdAt|date} from 'FOSMessageBundle' %}on{% endtrans %}
         </div>
 
-        <div class="messenger_thread_message_body" id="message_{{ message.id }}">
+        <div class="panel-body">
             {{ message.body }}
         </div>
     </div>

--- a/Resources/views/Message/threads_list.html.twig
+++ b/Resources/views/Message/threads_list.html.twig
@@ -1,4 +1,4 @@
-<table>
+<table class="table">
 
     <thead>
         <tr>
@@ -22,7 +22,7 @@
                     </a>
 
                     {% if not fos_message_is_read(thread) %}
-                        ({% trans from 'FOSMessageBundle' %}new{% endtrans %})
+                    <span class="label label-default">{% trans from 'FOSMessageBundle' %}new{% endtrans %}</span>
                     {% endif %}
                 </td>
                 <td>

--- a/Resources/views/layout.html.twig
+++ b/Resources/views/layout.html.twig
@@ -1,20 +1,25 @@
 <!DOCTYPE html>
 <html lang="en">
     <head>
+        <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.0.0/css/bootstrap.min.css">
         <meta http-equiv="Content-Type" content="text/html; charset={{ _charset }}" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>{% trans from 'FOSMessageBundle' %}messenger{% endtrans %}</title>
     </head>
 
     <body>
+        <div class="container">
 
         <h1>{% trans from 'FOSMessageBundle' %}messenger{% endtrans %}</h1>
 
-        <ul>
-            <li><a href="{{ url('fos_message_inbox') }}">{% trans from 'FOSMessageBundle' %}inbox{% endtrans %}</a></li>
-            <li><a href="{{ url('fos_message_sent') }}">{% trans from 'FOSMessageBundle' %}sent{% endtrans %}</a></li>
-        </ul>
+            <div class="btn-group">
+                <a href="{{ url('fos_message_thread_new' )}}"><button type="button" class="btn btn-default">{% trans from 'FOSMessageBundle' %}send_new{% endtrans %}</button></a>
+                <a href="{{ url('fos_message_inbox') }}"><button type="button" class="btn btn-default">{% trans from 'FOSMessageBundle' %}inbox{% endtrans %}</button></a>
+                <a href="{{ url('fos_message_sent') }}"><button type="button" class="btn btn-default">{% trans from 'FOSMessageBundle' %}sent{% endtrans %}</button></a>
+                <a href="{{ url('fos_message_deleted') }}"><button type="button" class="btn btn-default">{% trans from 'FOSMessageBundle' %}deleted{% endtrans %}</button></a>
+            </div>
 
         {% block fos_message_content %}{% endblock %}
-
+        </div>
     </body>
 </html>


### PR DESCRIPTION
I've updated the included template with bootstrap3. This is not an attempt to make a kick ass design. Authors would still need to overwrite these templates. Also the forms are not styled yet.

Another update is in the translations file. There is an unneeded (and from my experience not working) string -message_info so i deleted that one. I only did that for the english version for now.
# New template

![rsz_1inbox](https://f.cloud.github.com/assets/3365006/1348357/21514202-36c4-11e3-909c-71e6d99c0991.png)
![rsz_message](https://f.cloud.github.com/assets/3365006/1348358/2e8ef7ca-36c4-11e3-81de-26bf68308df9.png)
# Old template

![rsz_inbox_old](https://f.cloud.github.com/assets/3365006/1348383/da6e8e2a-36c4-11e3-83df-44ece843cbe0.png)
![rsz_message_old](https://f.cloud.github.com/assets/3365006/1348386/df687aa8-36c4-11e3-86ff-739e949b53d7.png)
