### PR TITLE
Update thread.html.twig

### DIFF
--- a/Resources/views/Message/thread.html.twig
+++ b/Resources/views/Message/thread.html.twig
@@ -7,7 +7,7 @@
 {% for message in thread.messages %}
     <div class="messenger_thread_message">
         <div class="messenger_thread_message_info">
-            {% trans with {'%sender%': message.sender|e, '%date%': message.createdAt|date} from 'FOSMessageBundle' %}by{% endtrans %}
+            {% trans with {'%sender%': message.sender|e, '%date%': message.createdAt|date} from 'FOSMessageBundle' %}message_info{% endtrans %}
         </div>
 
         <div class="messenger_thread_message_body" id="message_{{ message.id }}">


### PR DESCRIPTION
The current code produces:
By admin

With this patch it will produce:
By admin, on October 17, 2013 22:03

If we don't revert to the old behaviour we should delete message_info from the translation files since we don't use it anywhere else
