### PR TITLE
Cannot delete thread, complains about foreign key constraints

### DIFF
--- a/Resources/doc/01a-orm-models.md
+++ b/Resources/doc/01a-orm-models.md
@@ -148,7 +148,7 @@ class Thread extends BaseThread
     /**
      * @ORM\OneToMany(
      *   targetEntity="Acme\MessageBundle\Entity\Message",
-     *   mappedBy="thread"
+     *   mappedBy="thread", orphanRemoval=true
      * )
      * @var Message[]|\Doctrine\Common\Collections\Collection
      */


### PR DESCRIPTION
If I don't add the orphanRemoval part then when I try to do
```php
$threadManager->deleteThread($thread);
```
I get this exception

```
An exception occurred while executing 'DELETE FROM milia_pb_thread WHERE id = ?' with params [7]:

SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`srb3`.`milia_pb_message`, CONSTRAINT `FK_BC0833E1E2904019` FOREIGN KEY (`thread_id`) REFERENCES `milia_pb_thread` (`id`))
```

I updated the docs with the fix, but not sure if this fix is the best one.