### PR TITLE
Add Symfony form component to the composer requirements

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,9 +18,9 @@
     ],
     "require": {
         "php": ">=5.3.2",
+        "symfony/form": "~2.1",
         "symfony/framework-bundle": "~2.1",
-        "symfony/twig-bundle": "~2.1",
-        "symfony/form": "~2.1"
+        "symfony/twig-bundle": "~2.1"
     },
     "suggest": {
         "doctrine/doctrine-bundle": "dev-master",


### PR DESCRIPTION
I'm no expert in composer requirements but when working with this bundle in a netbeans project I noticed I required the form component to get autocompletion for the form classes.

So I think this needs to be a requirement. The framework bundle has no requirement for the form component
https://github.com/symfony/FrameworkBundle/blob/2.1/composer.json
