### PR TITLE
Composer requires symfony security

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.1",
+        "symfony/security": "~2.1",
         "symfony/twig-bundle": "~2.1"
     },
     "suggest": {


### PR DESCRIPTION
There are some instances where the code throws an 
Symfony\Component\Security\Core\Exception\AccessDeniedException
Also the controllers use it to get the current user.

Without this it's impossible to unit test this.
