### PR TITLE
ODM Bug with deleted message view

### DIFF
--- a/DocumentManager/ThreadManager.php
+++ b/DocumentManager/ThreadManager.php
@@ -146,7 +146,7 @@ class ThreadManager extends BaseThreadManager
     {
         return $this->repository->createQueryBuilder()
             ->field('metadata.isDeleted')->equals(true)
-            ->field('metadata.participantId')->equals($participant->getId())
+            ->field('metadata.participant.$id')->equals(new \MongoId($participant->getId()))
             ->sort('lastMessageDate', 'desc');
     }
 


### PR DESCRIPTION
Here is a fix for Mongodb users.
Actually the view of deleted threads return nothing because the mongodb query has a bug. It doesn't call the ObjectId of User.
