### PR TITLE
Fixes Akismet namespace

### DIFF
--- a/SpamDetection/AkismetSpamDetector.php
+++ b/SpamDetection/AkismetSpamDetector.php
@@ -2,7 +2,7 @@
 
 namespace FOS\MessageBundle\SpamDetection;
 
-use FOS\AkismetBundle\Akismet\AkismetInterface;
+use Ornicar\AkismetBundle\Akismet\AkismetInterface;
 use FOS\MessageBundle\FormModel\NewThreadMessage;
 use FOS\MessageBundle\Security\ParticipantProviderInterface;
 


### PR DESCRIPTION
The `FOS\AkismetBundle\Akismet\AkismetInterface` doesn't exit. It breaks the Akismet feature.
This PR fixes that by using the correct `Ornicar` namespace.
