### PR TITLE
Prevent lazy loading by joining thread, threadmeta, message, and message...

### DIFF
--- a/EntityManager/ThreadManager.php
+++ b/EntityManager/ThreadManager.php
@@ -87,8 +87,11 @@ class ThreadManager extends BaseThreadManager
     public function getParticipantInboxThreadsQueryBuilder(ParticipantInterface $participant)
     {
         return $this->repository->createQueryBuilder('t')
+            ->select('t, tm, p, m, mm')
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
+            ->innerJoin('t.messages', 'm')
+            ->innerJoin ->innerJoin('m.metadata', 'mm')
 
             // the participant is in the thread participants
             ->andWhere('p.id = :user_id')
@@ -138,8 +141,12 @@ class ThreadManager extends BaseThreadManager
     public function getParticipantSentThreadsQueryBuilder(ParticipantInterface $participant)
     {
         return $this->repository->createQueryBuilder('t')
+            ->select('t, tm, p, m, mm')
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
+            ->innerJoin('t.messages', 'm')
+            ->innerJoin ->innerJoin('m.metadata', 'mm')
+
 
             // the participant is in the thread participants
             ->andWhere('p.id = :user_id')
@@ -183,8 +190,12 @@ class ThreadManager extends BaseThreadManager
     public function getParticipantDeletedThreadsQueryBuilder(ParticipantInterface $participant)
     {
         return $this->repository->createQueryBuilder('t')
+            ->select('t, tm, p, m, mm')
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
+            ->innerJoin('t.messages', 'm')
+            ->innerJoin ->innerJoin('m.metadata', 'mm')
+
 
             // the participant is in the thread participants
             ->andWhere('p.id = :user_id')

--- a/EntityManager/ThreadManager.php
+++ b/EntityManager/ThreadManager.php
@@ -87,7 +87,7 @@ class ThreadManager extends BaseThreadManager
     public function getParticipantInboxThreadsQueryBuilder(ParticipantInterface $participant)
     {
         return $this->repository->createQueryBuilder('t')
-            ->select('t, tm, p, m, mm')
+            ->select('t', 'tm', 'p', 'm', 'mm')
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
             ->innerJoin('t.messages', 'm')
@@ -141,7 +141,7 @@ class ThreadManager extends BaseThreadManager
     public function getParticipantSentThreadsQueryBuilder(ParticipantInterface $participant)
     {
         return $this->repository->createQueryBuilder('t')
-            ->select('t, tm, p, m, mm')
+            ->select('t', 'tm', 'p', 'm', 'mm')
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
             ->innerJoin('t.messages', 'm')
@@ -190,7 +190,7 @@ class ThreadManager extends BaseThreadManager
     public function getParticipantDeletedThreadsQueryBuilder(ParticipantInterface $participant)
     {
         return $this->repository->createQueryBuilder('t')
-            ->select('t, tm, p, m, mm')
+            ->select('t', 'tm', 'p', 'm', 'mm')
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
             ->innerJoin('t.messages', 'm')

--- a/EntityManager/ThreadManager.php
+++ b/EntityManager/ThreadManager.php
@@ -91,7 +91,7 @@ class ThreadManager extends BaseThreadManager
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
             ->innerJoin('t.messages', 'm')
-            ->innerJoin ->innerJoin('m.metadata', 'mm')
+            ->innerJoin('m.metadata', 'mm')
 
             // the participant is in the thread participants
             ->andWhere('p.id = :user_id')
@@ -145,7 +145,7 @@ class ThreadManager extends BaseThreadManager
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
             ->innerJoin('t.messages', 'm')
-            ->innerJoin ->innerJoin('m.metadata', 'mm')
+            ->innerJoin('m.metadata', 'mm')
 
 
             // the participant is in the thread participants
@@ -194,7 +194,7 @@ class ThreadManager extends BaseThreadManager
             ->innerJoin('t.metadata', 'tm')
             ->innerJoin('tm.participant', 'p')
             ->innerJoin('t.messages', 'm')
-            ->innerJoin ->innerJoin('m.metadata', 'mm')
+            ->innerJoin('m.metadata', 'mm')
 
 
             // the participant is in the thread participants


### PR DESCRIPTION
...meta

I adjusted getParticipantInboxThreadsQueryBuilder, Sent, and Deleted to add two more joined and specifically select all four entities.  I use this to reduce the number of Doctrine queries because it would lazy load each message count and who created the last message leading to 3x the number of queries for each message in the inbox.  Any concerns ->select('t, tm, p, m, mm')?