### PR TITLE
Translate validation in French

### DIFF
--- a/Resources/translations/validators.fr.yml
+++ b/Resources/translations/validators.fr.yml
@@ -5,12 +5,12 @@ fos_message:
     blank: Pas de destinataires spécifié
   subject:
     blank: Vous devez entrer un sujet
-    too_short: Le sujet est trop court|Le sujet est trop court
-    too_long: Le sujet est trop long|Le sujet est trop long
+    short: Le sujet est trop court|Le sujet est trop court
+    long: Le sujet est trop long|Le sujet est trop long
   body:
     blank: Vous devez entrer un message
-    too_short: Le message est trop court
-    spam: Il semble que votre message soit du SPAM, il n'a pas été envoyé
+    short: Le message est trop court
+    spam: Il semble que votre message soit un SPAM, il n'a pas été envoyé
   not_authorized: Vous n'avez pas le droit d'envoyer ce message
   reply_not_authorized: Vous n'avez pas de droit de répondre dans cette discussion
-  self_recipient: Vous ne pouvez vous envoyer à vous-même un message
+  self_recipient: Vous ne pouvez pas vous envoyer un message à vous-même


### PR DESCRIPTION
As discussed in https://github.com/FriendsOfSymfony/FOSMessageBundle/issues/228, we create validation translations. Here is the french one.
