### PR TITLE
Fix deprecation error

### DIFF
--- a/Resources/translations/FOSMessageBundle.de.yml
+++ b/Resources/translations/FOSMessageBundle.de.yml
@@ -4,7 +4,7 @@ sent:           Postausgang
 deleted:        Gelöscht
 send_new:       Neue Nachricht senden
 search:         Suche
-threads_found:  %num% Konversation gefunden mit | %num% Konversationen gefunden mit
+threads_found:  "%num% Konversation gefunden mit | %num% Konversationen gefunden mit"
 
 message_info:   Von %sender%, am %date%
 reply:          Antworten

--- a/Resources/translations/FOSMessageBundle.en.yml
+++ b/Resources/translations/FOSMessageBundle.en.yml
@@ -4,7 +4,7 @@ sent:           Sent
 deleted:        Deleted
 send_new:       Send a new message
 search:         Search
-threads_found:  %num% thread found with | %num% threads found with
+threads_found:  "%num% thread found with | %num% threads found with"
 
 message_info:   By %sender%, on %date%
 reply:          Reply

--- a/Resources/translations/FOSMessageBundle.es.yml
+++ b/Resources/translations/FOSMessageBundle.es.yml
@@ -4,7 +4,7 @@ sent: Enviado
 deleted: Eliminados
 send_new: Enviar nuevo mensaje
 search: Buscar
-threads_found: %num% hilo encontrado | %num% hilos encontrados
+threads_found: "%num% hilo encontrado | %num% hilos encontrados"
 
 message_info: Por %sender%, el %date%
 reply: Responder

--- a/Resources/translations/FOSMessageBundle.fa.yml
+++ b/Resources/translations/FOSMessageBundle.fa.yml
@@ -4,7 +4,7 @@ sent:           ارسالی
 deleted:        حذف‌شده
 send_new:       فرستادن یک پیام جدید
 search:         جستجو
-threads_found:  %num% مورد یافت شد | %num% مورد یافت شد
+threads_found:  "%num% مورد یافت شد | %num% مورد یافت شد"
 
 message_info:   توسط %sender%، در %date%
 reply:          پاسخ

--- a/Resources/translations/FOSMessageBundle.fr.yml
+++ b/Resources/translations/FOSMessageBundle.fr.yml
@@ -4,7 +4,7 @@ sent:           Envoyés
 deleted:        Supprimés
 send_new:       Envoyer un nouveau message
 search:         Rechercher
-threads_found:  %num% conversation trouvée avec | %num% conversations trouvées avec
+threads_found:  "%num% conversation trouvée avec | %num% conversations trouvées avec"
 
 message_info:   De %sender%, le %date%
 reply:          Répondre

--- a/Resources/translations/FOSMessageBundle.it.yml
+++ b/Resources/translations/FOSMessageBundle.it.yml
@@ -4,7 +4,7 @@ sent:           Posta inviata
 deleted:        Cestino
 send_new:       Scrivere un nuovo messaggio
 search:         Cercare
-threads_found:  %num% conversazione trovata con | %num%  conversazioni trovate con
+threads_found:  "%num% conversazione trovata con | %num%  conversazioni trovate con"
 
 message_info:   Di %sender%, il %date%
 reply:          Rispondere

--- a/Resources/translations/FOSMessageBundle.nl.yml
+++ b/Resources/translations/FOSMessageBundle.nl.yml
@@ -4,7 +4,7 @@ sent:           Verzonden
 deleted:        Verwijderd
 send_new:       Verstuur een nieuw bericht
 search:         Zoek
-threads_found:  %num% bericht gevonden met | %num% berichten gevonden met
+threads_found:  "%num% bericht gevonden met | %num% berichten gevonden met"
 
 message_info:   Door %sender%, op %date%
 reply:          Reageer

--- a/Resources/translations/FOSMessageBundle.sk.yml
+++ b/Resources/translations/FOSMessageBundle.sk.yml
@@ -4,7 +4,7 @@ sent:           Odoslané správy
 deleted:        Vymazané správy
 send_new:       Napísať správu
 search:         Hľadať
-threads_found:  %num% Konverzácia nájdená s | %num% Konverzácií nájdených s
+threads_found:  "%num% Konverzácia nájdená s | %num% Konverzácií nájdených s"
 
 message_info:   Od %sender%, %date%
 reply:          Odpovedať
@@ -17,7 +17,7 @@ last_message:   Posledná správa
 actions:        Akcie
 new:            Nová
 goto_last:      Ísť na poslednú správu
-on:             %date%
+on:             "%date%"
 by:             od %sender%
 no_thread:      Neexistujú správy, ktoré by bolo možné zobraziť
 delete:         Vymazať

--- a/Resources/translations/FOSMessageBundle.sl.yml
+++ b/Resources/translations/FOSMessageBundle.sl.yml
@@ -4,7 +4,7 @@ sent:           Poslano
 deleted:        Izbrisano
 send_new:       Pošlji novo sporočilo
 search:         Iskanje
-threads_found:  %num% najden pogovor | %num% najdena pogovora | %num% najdeni pogovori | %num% najdenih pogovorov
+threads_found:  "%num% najden pogovor | %num% najdena pogovora | %num% najdeni pogovori | %num% najdenih pogovorov"
 
 message_info:   Od %sender%, %date%
 reply:          Odgovori
@@ -17,7 +17,7 @@ last_message:   Zadnje sporočilo
 actions:        Akcije
 new:            Novo
 goto_last:      Pojdi na zadnje sporočilo
-on:             %date%
+on:             "%date%"
 by:             Od %sender%
 no_thread:      Ni pogovorov za prikaz
 delete:         Izbriši

--- a/Resources/translations/FOSMessageBundle.sv.yml
+++ b/Resources/translations/FOSMessageBundle.sv.yml
@@ -3,7 +3,7 @@ inbox:          Inkorg
 sent:           Skickat
 send_new:       Skriv nytt meddelande
 search:         Sök
-threads_found:  %num% tråd hittad | %num% trådar hittade
+threads_found:  "%num% tråd hittad | %num% trådar hittade"
 
 message_info:   Av %sender%, den %date%
 reply:          Svara


### PR DESCRIPTION
Not quoting the scalar "%num% thread found with | %num% threads found with" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0