### PR TITLE
add function getLast(limit) in MessageManager

### DIFF
--- a/EntityManager/MessageManager.php
+++ b/EntityManager/MessageManager.php
@@ -185,4 +185,19 @@ class MessageManager extends BaseMessageManager
     {
         return new $this->metaClass();
     }
+
+    /**
+     * Return the last $limit messages, by default the value is 10
+     *
+     * @param int $limit
+     * @return mixed
+     */
+    public function getLast($limit =  10)
+    {
+        return $this->em->createQuery('m')
+            ->orderBy('m.id','desc')
+            ->setMaxResults($limit)
+            ->getQuery()
+            ->execute();
+    }
 }


### PR DESCRIPTION
I just added a helper to get the last message, by default the value is 10 but you can specify how many last messages do you want in the parameter. I test the function on my laptop and there is no bug :-)