### PR TITLE
fixed bug that was causing insert to fail (utf-8 problem)

### DIFF
--- a/Document/Thread.php
+++ b/Document/Thread.php
@@ -146,7 +146,14 @@ abstract class Thread extends AbstractThread
         }
 
         // we only need each word once
-        $this->keywords = implode(' ', array_unique(str_word_count(mb_strtolower($keywords, 'UTF-8'), 1)));
+        $keywords = array_unique(str_word_count(mb_strtolower($keywords, 'UTF-8'), 1));
+
+        //But ensure every single keyword will be UTF-8 encoded or Mongo would crash
+        array_walk($keywords, function($keyword, $key) use (&$keywords){
+            $keywords[$key] = utf8_encode($keyword);
+        });
+
+        $this->keywords = implode(' ', $keywords);
     }
 
     /**


### PR DESCRIPTION
When testing the bundle with special characters the mongo insert was failing. The problem was in the method generating the keywords not properly sanitised as UTF-8. As far as I can tell the root cause was the usage of array_unique. The fix I did works here.