### PR TITLE
Fixing SF4.3+ deprecation notice for `TreeBuilder`

### DIFF
--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,7 +18,12 @@ class Configuration implements ConfigurationInterface
     public function getConfigTreeBuilder()
     {
         $treeBuilder = new TreeBuilder('fos_message');
-        $rootNode = $treeBuilder->root('fos_message');
+        if (\method_exists($treeBuilder, 'getRootNode')) {
+            $rootNode = $treeBuilder->getRootNode();
+        } else {
+            // BC layer for symfony/config 4.1 and older
+            $rootNode = $treeBuilder->root('fos_message');
+        }
 
         $rootNode
             ->children()


### PR DESCRIPTION
Fixing Symfony 4.3+ about `Symfony\Component\Config\Definition\Builder\TreeBuilder` deprecation notice, using method `getRootNode()` instead of `root()` method.